### PR TITLE
Update Rubygems to 3.0.3 because of CVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-N/A
+## Changed
+
+- Updated Rubygems to version 3.0.3 (from 3.0.3) because of multiple security fixes that have been fixed, more here: http://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html [#14](https://github.com/kaspergrubbe/grubruby-jemalloc/pull/14)
 
 ## [8009] - 2019-01-31
 

--- a/tools/build.rb
+++ b/tools/build.rb
@@ -1,7 +1,7 @@
 grubruby_repoowner = 'kaspergrubbe'
 grubruby_reponame  = 'grubruby-jemalloc'
 grubruby_version   = '8009'
-rubygems_version   = '3.0.2'
+rubygems_version   = '3.0.3'
 bundler_version    = '2.0.1'
 
 def run_command(command)


### PR DESCRIPTION
http://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html