### PR TITLE
Upgrade rubygems to version 3.0.4 (from 3.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-N/A
+- Update Rubygems to version `3.0.4` (from version `3.0.3`), it includes minor enhancements and bug fixes, https://blog.rubygems.org/2019/06/14/3.0.4-released.html
 
 ## [8014] - 2019-06-13
 

--- a/tools/build.rb
+++ b/tools/build.rb
@@ -1,7 +1,7 @@
 grubruby_repoowner = 'kaspergrubbe'
 grubruby_reponame  = 'grubruby-jemalloc'
 grubruby_version   = '8014'
-rubygems_version   = '3.0.3'
+rubygems_version   = '3.0.4'
 bundler_version    = '2.0.2'
 
 def run_command(command)


### PR DESCRIPTION
https://blog.rubygems.org/2019/06/14/3.0.4-released.html